### PR TITLE
feat(permissions): update permissions

### DIFF
--- a/dev.opengoal.OpenGOAL.yml
+++ b/dev.opengoal.OpenGOAL.yml
@@ -12,7 +12,8 @@ sdk-extensions:
 
 finish-args:
   - --socket=x11
-  - --device=all
+  - --device=dri
+  - --device=input
   - --socket=pulseaudio
   - --share=network
   - --share=ipc

--- a/dev.opengoal.OpenGOAL.yml
+++ b/dev.opengoal.OpenGOAL.yml
@@ -10,7 +10,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
   - org.freedesktop.Sdk.Extension.rust-stable
 
-require-version: "1.15.6"
+require-version: "1.16.0"
 
 finish-args:
   - --socket=x11

--- a/dev.opengoal.OpenGOAL.yml
+++ b/dev.opengoal.OpenGOAL.yml
@@ -10,9 +10,8 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
   - org.freedesktop.Sdk.Extension.rust-stable
 
-require-version: "1.16.0"
-
 finish-args:
+  - --require-version=1.16.0
   - --socket=x11
   - --device=dri
   - --device=input

--- a/dev.opengoal.OpenGOAL.yml
+++ b/dev.opengoal.OpenGOAL.yml
@@ -10,6 +10,8 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
   - org.freedesktop.Sdk.Extension.rust-stable
 
+require-version: "1.15.6"
+
 finish-args:
   - --socket=x11
   - --device=dri


### PR DESCRIPTION
With the addition of the `device=input` permission we no longer need a blanket `device=all` as we only require the gpu acceleration and input (gamepad/keyboard)